### PR TITLE
CrossV2 - Cross-Scale Prediction + Cross-Scale Latent Loss

### DIFF
--- a/models_mae/__init__.py
+++ b/models_mae/__init__.py
@@ -36,7 +36,6 @@ def mae_vit_tiny_aug15(**kwargs):
         decoder_num_layers=4,
         decoder_num_heads=8,
         # Augmentation
-        use_random_grayscale=True,
         use_color_jitter=True,
         use_gaussian_blur=True,
         use_random_rotation=True,
@@ -56,7 +55,6 @@ def mae_vit_tiny_aug25(**kwargs):
         decoder_num_layers=4,
         decoder_num_heads=8,
         # Augmentation
-        use_random_grayscale=True,
         use_color_jitter=True,
         use_gaussian_blur=True,
         use_random_rotation=True,
@@ -76,7 +74,6 @@ def mae_vit_tiny_aug35(**kwargs):
         decoder_num_layers=4,
         decoder_num_heads=8,
         # Augmentation
-        use_random_grayscale=True,
         use_color_jitter=True,
         use_gaussian_blur=True,
         use_random_rotation=True,
@@ -97,7 +94,6 @@ def mae_vit_tiny_aug25_nrp(**kwargs):
         decoder_num_heads=8,
         # Augmentation
         global_prob=0.25,
-        use_random_grayscale=True,
         use_color_jitter=True,
         use_gaussian_blur=True,
         use_random_rotation=False,
@@ -117,7 +113,6 @@ def mae_vit_tiny_aug25_rp(**kwargs):
         decoder_num_heads=8,
         # Augmentation
         global_prob=0.25,
-        use_random_grayscale=False,
         use_color_jitter=False,
         use_gaussian_blur=False,
         use_random_rotation=True,
@@ -138,7 +133,6 @@ def mae_vit_tiny_aug50_rrc(**kwargs):
         # Augmentation
         use_random_resized_crop=True,
         random_resized_crop_scale=(0.2, 0.8),
-        use_random_grayscale=False,
         use_color_jitter=False,
         use_gaussian_blur=False,
         use_random_rotation=False,

--- a/models_mae/__init__.py
+++ b/models_mae/__init__.py
@@ -27,34 +27,6 @@ def mae_vit_tiny(**kwargs):
     return model
 
 
-def mae_vit_tiny_aug25(**kwargs):
-    model = MaskedAutoencoderViTAug(
-        dim_model=128,
-        encoder_num_layers=4,
-        encoder_num_heads=8,
-        decoder_embed_dim=256,
-        decoder_num_layers=4,
-        decoder_num_heads=8,
-        **kwargs,
-    )
-    return model
-
-
-def mae_vit_tiny_aug25_nrp(**kwargs):
-    model: MaskedAutoencoderViTAug = MaskedAutoencoderViTAug(
-        dim_model=128,
-        encoder_num_layers=4,
-        encoder_num_heads=8,
-        decoder_embed_dim=256,
-        decoder_num_layers=4,
-        decoder_num_heads=8,
-        use_random_rotation=False,
-        use_random_perspective=False,
-        **kwargs,
-    )
-    return model
-
-
 def mae_vit_tiny_aug15(**kwargs):
     model = MaskedAutoencoderViTAug(
         dim_model=128,
@@ -63,7 +35,33 @@ def mae_vit_tiny_aug15(**kwargs):
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
+        # Augmentation
+        use_random_grayscale=True,
+        use_color_jitter=True,
+        use_gaussian_blur=True,
+        use_random_rotation=True,
+        use_random_perspective=True,
         global_prob=0.15,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug25(**kwargs):
+    model = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        # Augmentation
+        use_random_grayscale=True,
+        use_color_jitter=True,
+        use_gaussian_blur=True,
+        use_random_rotation=True,
+        use_random_perspective=True,
+        global_prob=0.25,
         **kwargs,
     )
     return model
@@ -77,7 +75,75 @@ def mae_vit_tiny_aug35(**kwargs):
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
+        # Augmentation
+        use_random_grayscale=True,
+        use_color_jitter=True,
+        use_gaussian_blur=True,
+        use_random_rotation=True,
+        use_random_perspective=True,
         global_prob=0.35,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug25_nrp(**kwargs):
+    model: MaskedAutoencoderViTAug = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        # Augmentation
+        global_prob=0.25,
+        use_random_grayscale=True,
+        use_color_jitter=True,
+        use_gaussian_blur=True,
+        use_random_rotation=False,
+        use_random_perspective=False,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug25_rp(**kwargs):
+    model: MaskedAutoencoderViTAug = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        # Augmentation
+        global_prob=0.25,
+        use_random_grayscale=False,
+        use_color_jitter=False,
+        use_gaussian_blur=False,
+        use_random_rotation=True,
+        use_random_perspective=True,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug50_rrc(**kwargs):
+    model = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        # Augmentation
+        use_random_resized_crop=True,
+        random_resized_crop_scale=(0.2, 0.8),
+        use_random_grayscale=False,
+        use_color_jitter=False,
+        use_gaussian_blur=False,
+        use_random_rotation=False,
+        use_random_perspective=False,
+        global_prob=0.50,
         **kwargs,
     )
     return model

--- a/models_mae/__init__.py
+++ b/models_mae/__init__.py
@@ -7,8 +7,8 @@
 # --------------------------------------------------------
 
 from .models_mae import *
-from .models_mae_aug import *
 from .models_mae_cross import *
+from .models_mae_crossv2 import *
 from .models_mae_shunted import *
 from .models_mae_shunted_cross import *
 
@@ -27,117 +27,69 @@ def mae_vit_tiny(**kwargs):
     return model
 
 
-def mae_vit_tiny_aug15(**kwargs):
-    model = MaskedAutoencoderViTAug(
+def mae_vit_tiny_crossV2_psum_lsum_full(**kwargs):
+    model = MaskedAutoencoderViTCrossV2(
         dim_model=128,
         encoder_num_layers=4,
         encoder_num_heads=8,
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
-        # Augmentation
-        use_color_jitter=True,
-        use_gaussian_blur=True,
-        use_random_rotation=True,
-        use_random_perspective=True,
-        global_prob=0.15,
+        # Cross Args
+        losses_pred_reduction="sum",
+        lossed_latent_reduction="sum",
+        loss_latent_weight=1.0,
         **kwargs,
     )
     return model
 
 
-def mae_vit_tiny_aug25(**kwargs):
-    model = MaskedAutoencoderViTAug(
+def mae_vit_tiny_crossV2_psum_lsum_half(**kwargs):
+    model = MaskedAutoencoderViTCrossV2(
         dim_model=128,
         encoder_num_layers=4,
         encoder_num_heads=8,
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
-        # Augmentation
-        use_color_jitter=True,
-        use_gaussian_blur=True,
-        use_random_rotation=True,
-        use_random_perspective=True,
-        global_prob=0.25,
+        # Cross Args
+        losses_pred_reduction="sum",
+        lossed_latent_reduction="sum",
+        loss_latent_weight=0.5,
         **kwargs,
     )
     return model
 
 
-def mae_vit_tiny_aug35(**kwargs):
-    model = MaskedAutoencoderViTAug(
+def mae_vit_tiny_crossV2_pmean_lmean_full(**kwargs):
+    model = MaskedAutoencoderViTCrossV2(
         dim_model=128,
         encoder_num_layers=4,
         encoder_num_heads=8,
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
-        # Augmentation
-        use_color_jitter=True,
-        use_gaussian_blur=True,
-        use_random_rotation=True,
-        use_random_perspective=True,
-        global_prob=0.35,
+        # Cross Args
+        losses_pred_reduction="mean",
+        lossed_latent_reduction="mean",
+        loss_latent_weight=0.5,
         **kwargs,
     )
     return model
 
 
-def mae_vit_tiny_aug25_nrp(**kwargs):
-    model: MaskedAutoencoderViTAug = MaskedAutoencoderViTAug(
+def mae_vit_tiny_crossV2_pmean_lmean_half(**kwargs):
+    model = MaskedAutoencoderViTCrossV2(
         dim_model=128,
         encoder_num_layers=4,
         encoder_num_heads=8,
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
-        # Augmentation
-        global_prob=0.25,
-        use_color_jitter=True,
-        use_gaussian_blur=True,
-        use_random_rotation=False,
-        use_random_perspective=False,
-        **kwargs,
-    )
-    return model
-
-
-def mae_vit_tiny_aug25_rp(**kwargs):
-    model: MaskedAutoencoderViTAug = MaskedAutoencoderViTAug(
-        dim_model=128,
-        encoder_num_layers=4,
-        encoder_num_heads=8,
-        decoder_embed_dim=256,
-        decoder_num_layers=4,
-        decoder_num_heads=8,
-        # Augmentation
-        global_prob=0.25,
-        use_color_jitter=False,
-        use_gaussian_blur=False,
-        use_random_rotation=True,
-        use_random_perspective=True,
-        **kwargs,
-    )
-    return model
-
-
-def mae_vit_tiny_aug50_rrc(**kwargs):
-    model = MaskedAutoencoderViTAug(
-        dim_model=128,
-        encoder_num_layers=4,
-        encoder_num_heads=8,
-        decoder_embed_dim=256,
-        decoder_num_layers=4,
-        decoder_num_heads=8,
-        # Augmentation
-        use_random_resized_crop=True,
-        random_resized_crop_scale=(0.2, 0.8),
-        use_color_jitter=False,
-        use_gaussian_blur=False,
-        use_random_rotation=False,
-        use_random_perspective=False,
-        global_prob=0.50,
+        # Cross Args
+        losses_pred_reduction="mean",
+        lossed_latent_reduction="mean",
+        loss_latent_weight=0.5,
         **kwargs,
     )
     return model

--- a/models_mae/__init__.py
+++ b/models_mae/__init__.py
@@ -72,7 +72,7 @@ def mae_vit_tiny_crossV2_pmean_lmean_full(**kwargs):
         # Cross Args
         losses_pred_reduction="mean",
         lossed_latent_reduction="mean",
-        loss_latent_weight=0.5,
+        loss_latent_weight=1.0,
         **kwargs,
     )
     return model
@@ -94,6 +94,37 @@ def mae_vit_tiny_crossV2_pmean_lmean_half(**kwargs):
     )
     return model
 
+def mae_vit_tiny_crossV2_psum_lmean_full(**kwargs):
+    model = MaskedAutoencoderViTCrossV2(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        # Cross Args
+        losses_pred_reduction="sum",
+        lossed_latent_reduction="mean",
+        loss_latent_weight=1.0,
+        **kwargs,
+    )
+    return model
+
+def mae_vit_tiny_crossV2_psum_lmean_half(**kwargs):
+    model = MaskedAutoencoderViTCrossV2(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        # Cross Args
+        losses_pred_reduction="sum",
+        lossed_latent_reduction="mean",
+        loss_latent_weight=0.5,
+        **kwargs,
+    )
+    return model
 
 def mae_vit_tiny_cross(**kwargs):
     model = MaskedAutoencoderViTCross(

--- a/models_mae/__init__.py
+++ b/models_mae/__init__.py
@@ -7,9 +7,11 @@
 # --------------------------------------------------------
 
 from .models_mae import *
-from .models_mae_shunted import *
+from .models_mae_aug import *
 from .models_mae_cross import *
+from .models_mae_shunted import *
 from .models_mae_shunted_cross import *
+
 
 # --- MAE Models --- #
 def mae_vit_tiny(**kwargs):
@@ -20,6 +22,62 @@ def mae_vit_tiny(**kwargs):
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug25(**kwargs):
+    model = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug25_nrp(**kwargs):
+    model: MaskedAutoencoderViTAug = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        use_random_rotation=False,
+        use_random_perspective=False,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug15(**kwargs):
+    model = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        global_prob=0.15,
+        **kwargs,
+    )
+    return model
+
+
+def mae_vit_tiny_aug35(**kwargs):
+    model = MaskedAutoencoderViTAug(
+        dim_model=128,
+        encoder_num_layers=4,
+        encoder_num_heads=8,
+        decoder_embed_dim=256,
+        decoder_num_layers=4,
+        decoder_num_heads=8,
+        global_prob=0.35,
         **kwargs,
     )
     return model
@@ -148,6 +206,8 @@ def mae_vit_tiny_shunted_2st(**kwargs):
         **kwargs,
     )
     return model
+
+
 shunted_2s_mae_vit_tiny = mae_vit_tiny_shunted_2st
 
 
@@ -163,9 +223,11 @@ def mae_vit_tiny_shunted_2st_cross(**kwargs):
         decoder_embed_dim=256,
         decoder_num_layers=4,
         decoder_num_heads=8,
-        **kwargs
+        **kwargs,
     )
     return model
+
+
 shunted_2s_mae_vit_tiny_cross = mae_vit_tiny_shunted_2st_cross
 
 
@@ -184,6 +246,8 @@ def mae_vit_mini_shunted_2st(**kwargs):
         **kwargs,
     )
     return model
+
+
 shunted_2s_mae_vit_mini = mae_vit_mini_shunted_2st
 
 
@@ -202,6 +266,8 @@ def mae_vit_small_shunted_2st(**kwargs):
         **kwargs,
     )
     return model
+
+
 shunted_2s_mae_vit_small = mae_vit_small_shunted_2st
 
 
@@ -220,6 +286,8 @@ def mae_vit_small_shunted_2st_cross(**kwargs):
         **kwargs,
     )
     return model
+
+
 shunted_2s_mae_vit_small_cross = mae_vit_small_shunted_2st_cross
 
 
@@ -238,6 +306,8 @@ def mae_vit_base_shunted_2st(**kwargs):
         **kwargs,
     )
     return model
+
+
 shunted_2s_mae_vit_base = mae_vit_base_shunted_2st
 
 
@@ -256,5 +326,6 @@ def mae_vit_base_shunted_2st_cross(**kwargs):
         **kwargs,
     )
     return model
-shunted_2s_mae_vit_base_cross = mae_vit_base_shunted_2st_cross
 
+
+shunted_2s_mae_vit_base_cross = mae_vit_base_shunted_2st_cross

--- a/models_mae/models_mae.py
+++ b/models_mae/models_mae.py
@@ -54,6 +54,7 @@ class MaskedAutoencoderViT(nn.Module):
         self.decoder_embed_dim = decoder_embed_dim
         self.mask_ratio = mask_ratio
         self.loss = loss.lower()
+        print(f"Loss: {self.loss}")
 
         self.use_xformers = use_xformers
 
@@ -441,7 +442,7 @@ class MaskedAutoencoderViT(nn.Module):
         loss = (loss * mask).sum() / mask.sum() if mask is not None else loss.mean()
         return loss
 
-    def forward(self, imgs, mask_ratio=0.75, mask_seed=None):
+    def forward(self, imgs, mask_ratio=0.75, mask_seed=None, return_latent=False):
         if mask_seed is not None:
             torch.manual_seed(mask_seed)
 
@@ -457,4 +458,4 @@ class MaskedAutoencoderViT(nn.Module):
         else:
             raise ValueError(f"Loss type {self.loss} not supported.")
 
-        return loss, pred, mask
+        return (loss, pred, mask, latent) if return_latent else (loss, pred, mask)

--- a/models_mae/models_mae_aug.py
+++ b/models_mae/models_mae_aug.py
@@ -18,8 +18,7 @@ class MaskedAutoencoderViTAug(MaskedAutoencoderViT):
         # Random resized crop
         use_random_resized_crop: bool = False,
         random_resized_crop_scale: tuple = (0.2, 0.8),
-        # Color-related (brightness, contrast, saturation, hue, grayscale)
-        use_random_grayscale: bool = False,
+        # Color-related (brightness, contrast, saturation, hue)
         use_color_jitter: bool = False,
         color_jitter_intensity: float = 0.2,
         # Gaussian blur
@@ -52,9 +51,6 @@ class MaskedAutoencoderViTAug(MaskedAutoencoderViT):
                     p=global_prob,
                 )
             )
-
-        if use_random_grayscale:
-            transforms.append(T.RandomGrayscale(p=global_prob))
 
         if use_color_jitter:
             transforms.append(

--- a/models_mae/models_mae_aug.py
+++ b/models_mae/models_mae_aug.py
@@ -15,31 +15,47 @@ class MaskedAutoencoderViTAug(MaskedAutoencoderViT):
 
     def __init__(
         self,
-        use_random_grayscale: bool = True,
-        use_color_jitter: bool = True,
+        # Random resized crop
+        use_random_resized_crop: bool = False,
+        random_resized_crop_scale: tuple = (0.2, 0.8),
+        # Color-related (brightness, contrast, saturation, hue, grayscale)
+        use_random_grayscale: bool = False,
+        use_color_jitter: bool = False,
         color_jitter_intensity: float = 0.2,
-        use_random_rotation: bool = True,
-        rotation_degrees: float = 15,
-        use_random_perspective: bool = True,
-        perspective_distortion_scale: float = 0.15,
-        use_gaussian_blur: bool = True,
+        # Gaussian blur
+        use_gaussian_blur: bool = False,
         gaussian_blur_sigma: float = 5.0,
         gaussian_blur_kernel_size: int = 5,
+        # Rotation and perspective
+        use_random_rotation: bool = False,
+        rotation_degrees: float = 15,
+        use_random_perspective: bool = False,
+        perspective_distortion_scale: float = 0.15,
+        # Probability of applying each augmentation
         global_prob: float = 0.25,
         **kwargs,
     ):
         super().__init__(**kwargs)
 
-        # applying random types of noise of a random intensity, as well as color jittering and other augmentations
         transforms = []
-        # T.RandomGrayscale(p=0.1),
-        #     T.RandomApply([T.ColorJitter(0.2, 0.2, 0.2, 0.2)], p=0.25),
-        #     T.RandomApply([T.GaussianBlur(5, sigma=(0.1, 5.0))], p=0.25),
-        #     T.RandomApply([T.RandomRotation(degrees=15, expand=False)], p=0.25),
-        #     T.RandomPerspective(distortion_scale=0.15, p=0.25),
+
+        if use_random_resized_crop:
+            transforms.append(
+                T.RandomApply(
+                    [
+                        T.RandomResizedCrop(
+                            size=(self.input_size, self.input_size),
+                            scale=random_resized_crop_scale,
+                            antialias=True,
+                        )
+                    ],
+                    p=global_prob,
+                )
+            )
 
         if use_random_grayscale:
             transforms.append(T.RandomGrayscale(p=global_prob))
+
         if use_color_jitter:
             transforms.append(
                 T.RandomApply(
@@ -54,6 +70,7 @@ class MaskedAutoencoderViTAug(MaskedAutoencoderViT):
                     p=global_prob,
                 )
             )
+
         if use_random_rotation:
             transforms.append(
                 T.RandomApply(
@@ -61,6 +78,7 @@ class MaskedAutoencoderViTAug(MaskedAutoencoderViT):
                     p=global_prob,
                 )
             )
+
         if use_random_perspective:
             transforms.append(
                 T.RandomApply(
@@ -71,6 +89,7 @@ class MaskedAutoencoderViTAug(MaskedAutoencoderViT):
                     ]
                 )
             )
+
         if use_gaussian_blur:
             transforms.append(
                 T.RandomApply(

--- a/models_mae/models_mae_aug.py
+++ b/models_mae/models_mae_aug.py
@@ -1,0 +1,95 @@
+import random
+
+import torch
+import torch.nn as nn
+from torchvision import transforms as T
+
+# xformers._is_functorch_available = True
+import viz
+
+from .models_mae import MaskedAutoencoderViT
+
+
+class MaskedAutoencoderViTAug(MaskedAutoencoderViT):
+    """Masked Autoencoder with VisionTransformer backbone"""
+
+    def __init__(
+        self,
+        use_random_grayscale: bool = True,
+        use_color_jitter: bool = True,
+        color_jitter_intensity: float = 0.2,
+        use_random_rotation: bool = True,
+        rotation_degrees: float = 15,
+        use_random_perspective: bool = True,
+        perspective_distortion_scale: float = 0.15,
+        use_gaussian_blur: bool = True,
+        gaussian_blur_sigma: float = 5.0,
+        gaussian_blur_kernel_size: int = 5,
+        global_prob: float = 0.25,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+
+        # applying random types of noise of a random intensity, as well as color jittering and other augmentations
+        transforms = []
+        # T.RandomGrayscale(p=0.1),
+        #     T.RandomApply([T.ColorJitter(0.2, 0.2, 0.2, 0.2)], p=0.25),
+        #     T.RandomApply([T.GaussianBlur(5, sigma=(0.1, 5.0))], p=0.25),
+        #     T.RandomApply([T.RandomRotation(degrees=15, expand=False)], p=0.25),
+        #     T.RandomPerspective(distortion_scale=0.15, p=0.25),
+
+        if use_random_grayscale:
+            transforms.append(T.RandomGrayscale(p=global_prob))
+        if use_color_jitter:
+            transforms.append(
+                T.RandomApply(
+                    [
+                        T.ColorJitter(
+                            color_jitter_intensity,
+                            color_jitter_intensity,
+                            color_jitter_intensity,
+                            color_jitter_intensity,
+                        )
+                    ],
+                    p=global_prob,
+                )
+            )
+        if use_random_rotation:
+            transforms.append(
+                T.RandomApply(
+                    [T.RandomRotation(degrees=rotation_degrees, expand=False)],
+                    p=global_prob,
+                )
+            )
+        if use_random_perspective:
+            transforms.append(
+                T.RandomApply(
+                    [
+                        T.RandomPerspective(
+                            distortion_scale=perspective_distortion_scale, p=global_prob
+                        )
+                    ]
+                )
+            )
+        if use_gaussian_blur:
+            transforms.append(
+                T.RandomApply(
+                    [
+                        T.GaussianBlur(
+                            gaussian_blur_kernel_size,
+                            sigma=(gaussian_blur_sigma, gaussian_blur_sigma),
+                        )
+                    ],
+                    p=global_prob,
+                )
+            )
+
+        self.augment1 = nn.Sequential(*transforms)
+
+    def forward(self, imgs, mask_ratio=0.75, mask_seed: int = None):
+        if mask_seed is not None:
+            torch.manual_seed(mask_seed)
+
+        imgs = self.augment1(imgs)
+
+        return super().forward(imgs, mask_ratio=mask_ratio, mask_seed=mask_seed)

--- a/models_mae/models_mae_crossv2.py
+++ b/models_mae/models_mae_crossv2.py
@@ -59,74 +59,33 @@ class MaskedAutoencoderViTCrossV2(MaskedAutoencoderViT):
             )
         )
 
-        # T.RandomApply(
-        #     [
-        #         T.RandomResizedCrop(
-        #             size=(self.input_size, self.input_size),
-        #             scale=random_resized_crop_scale,
-        #             antialias=True,
-        #         )
-        #     ],
-        #     p=global_prob,
-        # )
-
-        # T.RandomApply(
-        #     [
-        #         T.ColorJitter(
-        #             color_jitter_intensity,
-        #             color_jitter_intensity,
-        #             color_jitter_intensity,
-        #             color_jitter_intensity,
-        #         )
-        #     ],
-        #     p=global_prob,
-        # )
-
-        # T.RandomApply(
-        #     [T.RandomRotation(degrees=rotation_degrees, expand=False)],
-        #     p=global_prob,
-        # )
-
-        # T.RandomApply(
-        #     [
-        #         T.RandomPerspective(
-        #             distortion_scale=perspective_distortion_scale, p=global_prob
-        #         )
-        #     ]
-        # )
-
-        # T.RandomApply(
-        #     [
-        #         T.GaussianBlur(
-        #             gaussian_blur_kernel_size,
-        #             sigma=(gaussian_blur_sigma, gaussian_blur_sigma),
-        #         )
-        #     ],
-        #     p=global_prob,
-        # )
-
-        # self.augment1 = nn.Sequential(*transforms)
-
     def forward(self, imgs, mask_ratio=0.75, mask_seed: int = None):
         if mask_seed is not None:
             torch.manual_seed(mask_seed)
 
+        # Cropped images
         imgs_crop_sm, imgs_crop_md = self.crop_sm(imgs), self.crop_md(imgs)
 
-        loss_crop_sm, _, _, latent_crop_sm = super().forward(
-            imgs_crop_sm, mask_ratio=mask_ratio, mask_seed=mask_seed, return_latent=True
-        )
-        loss_crop_md, _, _, latent_crop_md = super().forward(
-            imgs_crop_md, mask_ratio=mask_ratio, mask_seed=mask_seed, return_latent=True
-        )
+        # Forward Original image
         loss_orig, pred_orig, mask_orig, latent_orig = super().forward(
             imgs, mask_ratio=mask_ratio, mask_seed=mask_seed, return_latent=True
         )
+        # Forward Small crop
+        loss_crop_sm, _, _, latent_crop_sm = super().forward(
+            imgs_crop_sm, mask_ratio=mask_ratio, mask_seed=mask_seed, return_latent=True
+        )
+        # Forward Medium crop
+        loss_crop_md, _, _, latent_crop_md = super().forward(
+            imgs_crop_md, mask_ratio=mask_ratio, mask_seed=mask_seed, return_latent=True
+        )
 
+        # Reducing losses for reconstruction based on decoder predictions
         losses_pred = [loss_orig, loss_crop_sm, loss_crop_md]
+        losses_pred_reduced = sum(losses_pred)
+        if self.losses_pred_reduction == "mean":
+            losses_pred_reduced /= len(losses_pred)
 
-        # latent loss between each crop and original
-        # as well as between crops themselves
+        # Latent loss function
         latent_loss_fn = None
         if self.loss_latent == "mse":
             latent_loss_fn = nn.MSELoss(reduction="mean")
@@ -135,23 +94,23 @@ class MaskedAutoencoderViTCrossV2(MaskedAutoencoderViT):
         else:
             raise ValueError(f"Unknown latent loss: {self.latent_loss}")
 
+        # latent loss between each crop and original
+        # as well as between crops themselves
         losses_latent = [
             latent_loss_fn(latent_crop_sm, latent_orig),
             latent_loss_fn(latent_crop_md, latent_orig),
             latent_loss_fn(latent_crop_sm, latent_crop_md),
         ]
 
-        print(f"losses_pred: {losses_pred}")
-        print(f"losses_latent: {losses_latent}")
-
-        losses_pred_reduced = sum(losses_pred)
-        if self.losses_pred_reduction == "mean":
-            losses_pred_reduced /= len(losses_pred)
-
+        # Reducing losses for latent space from encoder output
         losses_latent_reduced = sum(losses_latent)
         if self.lossed_latent_reduction == "mean":
             losses_latent_reduced /= len(losses_latent)
 
+        # Merging losses:
+        # - minimizing distance between latent spaces of crops and original (weighted)
+        # and
+        # - minimizing reconstruction loss for decoder predictions
         loss_final = (
             losses_pred_reduced + self.loss_latent_weight * losses_latent_reduced
         )

--- a/models_mae/models_mae_crossv2.py
+++ b/models_mae/models_mae_crossv2.py
@@ -115,4 +115,5 @@ class MaskedAutoencoderViTCrossV2(MaskedAutoencoderViT):
             losses_pred_reduced + self.loss_latent_weight * losses_latent_reduced
         )
 
+        # Returning the final loss, original prediction and mask (of original image only)
         return loss_final, pred_orig, mask_orig

--- a/viz.py
+++ b/viz.py
@@ -152,6 +152,7 @@ def add_noise(image, noise_type="gaussian", noise_param=0.1):
     # if noise type is random, randomly choose one of the other types
     if noise_type == "random":
         noise_type = np.random.choice(["gaussian", "poisson", "s&p", "speckle"])
+
     if noise_type == "gaussian":
         noise = np.random.normal(0, noise_param, image.shape)
     elif noise_type == "poisson":

--- a/viz.py
+++ b/viz.py
@@ -149,18 +149,34 @@ def prepare_image(image_uri, model, random_crop=False, crop_seed=None, resample=
 
 
 def add_noise(image, noise_type="gaussian", noise_param=0.1):
+    # if noise type is random, randomly choose one of the other types
+    if noise_type == "random":
+        noise_type = np.random.choice(["gaussian", "poisson", "s&p", "speckle"])
     if noise_type == "gaussian":
         noise = np.random.normal(0, noise_param, image.shape)
     elif noise_type == "poisson":
         noise = np.random.poisson(noise_param, image.shape)
     elif noise_type == "s&p":
         noise = np.random.binomial(1, noise_param, image.shape)
-    elif noise_type == "speckle":
-        noise = np.random.normal(0, noise_param, image.shape)
     else:
         raise ValueError("Invalid noise type")
 
-    noisy_image = image + noise
+    noisy_image = image + noise.to(image.dtype)
+    return noisy_image
+
+
+def add_noise_torch(image, noise_type="gaussian", noise_param=0.1):
+    # create a tensor the same size as the image
+    if noise_type == "gaussian":
+        noise = torch.randn_like(image) * noise_param
+    elif noise_type == "poisson":
+        noise = torch.poisson(torch.ones_like(image) * noise_param)
+    elif noise_type == "s&p":
+        noise = torch.bernoulli(torch.ones_like(image) * noise_param)
+    else:
+        raise ValueError("Invalid noise type")
+
+    noisy_image = image + noise.to(image.device)
     return noisy_image
 
 

--- a/viz.py
+++ b/viz.py
@@ -162,7 +162,7 @@ def add_noise(image, noise_type="gaussian", noise_param=0.1):
     else:
         raise ValueError("Invalid noise type")
 
-    noisy_image = image + noise.to(image.dtype)
+    noisy_image = image + noise
     return noisy_image
 
 

--- a/viz.py
+++ b/viz.py
@@ -151,7 +151,7 @@ def prepare_image(image_uri, model, random_crop=False, crop_seed=None, resample=
 def add_noise(image, noise_type="gaussian", noise_param=0.1):
     # if noise type is random, randomly choose one of the other types
     if noise_type == "random":
-        noise_type = np.random.choice(["gaussian", "poisson", "s&p", "speckle"])
+        noise_type = np.random.choice(["gaussian", "poisson", "s&p"])
 
     if noise_type == "gaussian":
         noise = np.random.normal(0, noise_param, image.shape)

--- a/viz.py
+++ b/viz.py
@@ -162,8 +162,7 @@ def add_noise(image, noise_type="gaussian", noise_param=0.1):
     else:
         raise ValueError("Invalid noise type")
 
-    noisy_image = image + noise
-    return noisy_image
+    return image + noise
 
 
 def add_noise_torch(image, noise_type="gaussian", noise_param=0.1):
@@ -177,8 +176,7 @@ def add_noise_torch(image, noise_type="gaussian", noise_param=0.1):
     else:
         raise ValueError("Invalid noise type")
 
-    noisy_image = image + noise.to(image.device)
-    return noisy_image
+    return image + noise.to(image.device)
 
 
 @torch.no_grad()


### PR DESCRIPTION
Introduces several tweaks and improvements to the cross-scale architecture. This is named CrossV2, to keep separate from the original implementation.

2 different crops are used in this version:
1. small crop (random scale from 0.1 to 0.4 of original)
2. medium crop (random scale from 0.4 to 0.7 of original)

Feedforward procedure:
- Feedforward original, small crop, and medium crop images. To get the decoder's reconstruction loss and encoder's latent space from each of the 3 different scales (original scale, small crop scale, medium crop scale)
  - Reduction: The 3 reconstruction losses are reduced according to parameter (either "mean" or "sum")
- Additional loss components to Minimize the cross-scale loss between:
    1. small crop and original latent dims
    2. medium crop and original latent dims
    3. small crop and medium crop latent dims
  - Reduction: The 3 latent losses are reduced according to parameter (either "mean" or "sum")
- Optionally, set a weight to the latent loss component (default 1.0, but may need to be tweaked)
- Final loss: reduced pred loss + latent loss weight * reduced latent loss

TODO: Cosine similarity latent loss func?

Please let me know your thoughts